### PR TITLE
[polylfo] add output scaling

### DIFF
--- a/software/o_c_REV/APP_POLYLFO.ino
+++ b/software/o_c_REV/APP_POLYLFO.ino
@@ -45,10 +45,12 @@ enum POLYLFO_SETTINGS {
   POLYLFO_SETTING_B_XOR_A,
   POLYLFO_SETTING_C_XOR_A,
   POLYLFO_SETTING_D_XOR_A,
+  POLYLFO_SETTING_AMPLITUDE_SCALING_A,
+  POLYLFO_SETTING_AMPLITUDE_SCALING_B,
+  POLYLFO_SETTING_AMPLITUDE_SCALING_C,
+  POLYLFO_SETTING_AMPLITUDE_SCALING_D,
   POLYLFO_SETTING_LAST
 };
-
-
 
 class PolyLfo : public settings::SettingsBase<PolyLfo, POLYLFO_SETTING_LAST> {
 public:
@@ -97,10 +99,26 @@ public:
     return values_[POLYLFO_SETTING_C_XOR_A];
   }
 
- uint8_t get_d_xor_a() const {
+  uint8_t get_d_xor_a() const {
     return values_[POLYLFO_SETTING_D_XOR_A];
   }
+
+  uint16_t get_amplitude_scaling_a() const {
+    return values_[POLYLFO_SETTING_AMPLITUDE_SCALING_A];
+  }
+
+  uint16_t get_amplitude_scaling_b() const {
+    return values_[POLYLFO_SETTING_AMPLITUDE_SCALING_B];
+  }
+
+  uint16_t get_amplitude_scaling_c() const {
+    return values_[POLYLFO_SETTING_AMPLITUDE_SCALING_C];
+  }
   
+  uint16_t get_amplitude_scaling_d() const {
+    return values_[POLYLFO_SETTING_AMPLITUDE_SCALING_D];
+  }
+
   void Init();
 
   void freeze() {
@@ -154,6 +172,10 @@ SETTINGS_DECLARE(PolyLfo, POLYLFO_SETTING_LAST) {
   { 0, 0, 8, "B XOR A", xor_levels, settings::STORAGE_TYPE_U4 },
   { 0, 0, 8, "C XOR A", xor_levels, settings::STORAGE_TYPE_U4 },
   { 0, 0, 8, "D XOR A", xor_levels, settings::STORAGE_TYPE_U4 }, 
+  { 255, 0, 255, "Ampl scaling A", NULL, settings::STORAGE_TYPE_U8 }, 
+  { 255, 0, 255, "Ampl scaling B", NULL, settings::STORAGE_TYPE_U8 }, 
+  { 255, 0, 255, "Ampl scaling C", NULL, settings::STORAGE_TYPE_U8 }, 
+  { 255, 0, 255, "Ampl scaling D", NULL, settings::STORAGE_TYPE_U8 }, 
  };
 
 PolyLfo poly_lfo;
@@ -198,6 +220,9 @@ void FASTRUN POLYLFO_isr() {
   poly_lfo.lfo.set_b_xor_a(poly_lfo.get_b_xor_a());
   poly_lfo.lfo.set_c_xor_a(poly_lfo.get_c_xor_a());
   poly_lfo.lfo.set_d_xor_a(poly_lfo.get_d_xor_a());
+
+  poly_lfo.lfo.set_amplitude_scalings(SCALE8_16(poly_lfo.get_amplitude_scaling_a()), SCALE8_16(poly_lfo.get_amplitude_scaling_b()), 
+                              SCALE8_16(poly_lfo.get_amplitude_scaling_c()), SCALE8_16(poly_lfo.get_amplitude_scaling_d()));
 
   if (!freeze && !poly_lfo.frozen())
     poly_lfo.lfo.Render(freq, reset_phase);

--- a/software/o_c_REV/frames_poly_lfo.h
+++ b/software/o_c_REV/frames_poly_lfo.h
@@ -170,7 +170,14 @@ class PolyLfo {
   inline uint8_t level(uint8_t index) const {
     return level_[index];
   }
- 
+
+  inline void set_amplitude_scalings(uint16_t amp_scaling_a, uint16_t amp_scaling_b, uint16_t amp_scaling_c, uint16_t amp_scaling_d) {
+    amplitude_scalings_[0] = amp_scaling_a;
+    amplitude_scalings_[1] = amp_scaling_b;
+    amplitude_scalings_[2] = amp_scaling_c;
+    amplitude_scalings_[3] = amp_scaling_d;
+  }
+
   inline const uint16_t dac_code(uint8_t index) const {
     return dac_code_[index];
   }
@@ -186,13 +193,14 @@ class PolyLfo {
   PolyLfoFreqDivisions freq_div_b_;
   PolyLfoFreqDivisions freq_div_c_;
   PolyLfoFreqDivisions freq_div_d_;
+  uint16_t amplitude_scalings_[kNumChannels];
   uint8_t b_xor_a_ ;
   uint8_t c_xor_a_ ;
   uint8_t d_xor_a_ ;
   bool phase_reset_flag_ ;
 
   int16_t value_[kNumChannels];
-  int16_t wt_value_[kNumChannels];
+  int32_t wt_value_[kNumChannels];
   uint32_t phase_[kNumChannels];
   uint32_t phase_increment_ch1_;
   uint8_t level_[kNumChannels];


### PR DESCRIPTION
At the expense of 4 more bytes of settings storage, this adds output scaling for each channel in Quadraturia. Very useful when XORing the outputs, or mixing without attenuators (e.g. in MI Links), or when feeding to an input which doesn't have an attenuator.
